### PR TITLE
fix hash ordering for hash dot operation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ion-binary-rs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Couragium Solutions <info@couragium.com>"]
 edition = "2018"
 description="Pure Rust parser, encoder and hasher for Amazon's Ion binary format."

--- a/src/ion_hash.rs
+++ b/src/ion_hash.rs
@@ -176,6 +176,7 @@ impl<D: Digest> PartialOrd for IonHash<D> {
         self.buffer
             .iter()
             .rev()
-            .partial_cmp(value.get().iter().rev())
+            .map(|byte| *byte as i8)
+            .partial_cmp(value.get().iter().rev().map(|byte| *byte as i8))
     }
 }


### PR DESCRIPTION
This fix makes the QLDB Driver first test to work :partying_face: 